### PR TITLE
Add Aiven Oy

### DIFF
--- a/data/cloud_software/aiven.json
+++ b/data/cloud_software/aiven.json
@@ -1,0 +1,16 @@
+{
+    "name": "Aiven",
+    "career_page_url": "https://aiven.io/careers",
+    "url": "https://aiven.io",
+    "remote_policy": "Full",
+    "hiring_policy": "Direct",
+    "type": "Product",
+    "tags": [
+        "AWS",
+        "GCP",
+        "Python",
+        "PostgreSQL",
+        "Kafka",
+        "Databases"
+    ]
+}


### PR DESCRIPTION
Database as a service. Direct hiring through Aiven Italy Srl. No engineering offices in Italy.