### PR TITLE
added bending spoons and meta in cloud_software category

### DIFF
--- a/data/bendingspoons.json
+++ b/data/bendingspoons.json
@@ -4,5 +4,5 @@
   "career_page_url": "https://bendingspoons.com/careers.html",
   "categories": ["marketing_writing", "cloud_software"],
   "remote_policy": "-",
-  "hiring_policies": ["-"]
+  "hiring_policies": ["Direct"]
 }

--- a/data/bendingspoons.json
+++ b/data/bendingspoons.json
@@ -2,11 +2,7 @@
   "name": "BendingSpoons",
   "url": "https://bendingspoons.com/",
   "career_page_url": "https://bendingspoons.com/careers.html",
-  "categories": [
-    "marketing_writing"
-  ],
+  "categories": ["marketing_writing", "cloud_software"],
   "remote_policy": "-",
-  "hiring_policies": [
-    "-"
-  ]
+  "hiring_policies": ["-"]
 }

--- a/data/meta.json
+++ b/data/meta.json
@@ -2,13 +2,7 @@
   "name": "Meta",
   "url": "https://about.facebook.com/meta/",
   "career_page_url": "https://www.metacareers.com/jobs?roles[0]=full-time\u0026offices[0]=Remote%2C%20Italy",
-  "categories": [
-    "design_ux",
-    "hr",
-    "marketing_writing"
-  ],
+  "categories": ["design_ux", "hr", "marketing_writing", "cloud_software"],
   "remote_policy": "-",
-  "hiring_policies": [
-    "-"
-  ]
+  "hiring_policies": ["-"]
 }


### PR DESCRIPTION
Hi!i added both bending spoons and meta in the cloud_software category since i saw they were missing. Meta has plenty of engeenering positions as you can see here https://www.metacareers.com/jobs/?is_leadership=0&is_in_page=0&offices[0]=Remote%2C%20Italy&page=4 and so does Bending Spoons: https://bendingspoons.com/careers.html. They should also assume directly with an italian contract but i'm not sure 100%. Meta has specificly "remote, italy" so it's definetely a green flag. I also saw on reddit posts of italian who work remotely there with an italian contract. Bending spoons is based in Milan so i'm almost 100% sure they hire in direct mode. Let me know if i should also add "direct" to them!