### PR TITLE
Add Giant Swarm

### DIFF
--- a/data/giant_swarm.json
+++ b/data/giant_swarm.json
@@ -1,0 +1,26 @@
+{
+    "name": "Giant Swarm",
+    "career_page_url": "https://www.giantswarm.io/careers#open-positions",
+    "url": "https://giantswarm.io",
+    "remote_policy": "Full",
+    "hiring_policies": [
+        "Contract",
+        "Intermediary"
+    ],
+    "type": "Product",
+    "categories": [
+        "cloud_software"
+    ],
+    "tags": [
+        "Kubernetes",
+        "Go",
+        "AWS",
+        "Azure",
+        "GCP",
+        "Openstack",
+        "VMWare",
+        "DevOps",
+        "Cloud Native",
+        "Security"
+    ]
+}


### PR DESCRIPTION
With this PR I am adding Giant Swarm to this list of companies hiring remotely in Italy. The company is based in Germany and its employees live in countries ranging from Korea to Argentina.