### PR TITLE
Added Shielder

### DIFF
--- a/data/shielder.json
+++ b/data/shielder.json
@@ -1,0 +1,20 @@
+{
+    "name": "Shielder",
+    "career_page_url": "https://www.shielder.com/careers/",
+    "url": "https://www.shielder.com/",
+    "remote_policy": "Optional",
+    "hiring_policies": [
+        "Direct"
+    ],
+    "type": "B2B",
+    "categories": [
+        "cybersecurity"
+    ],
+    "tags": [
+        "Penetration Test",
+        "Security Research",
+        "Application Security",
+        "Red Teaming",
+        "Hardware Security"
+    ]
+}


### PR DESCRIPTION
Added Shielder - a Cybersecurity company offering remote positions for Penetration Testers, Red Team Operators, and Security Researchers.