### PR TITLE
Remove unnecessary line break in redlab.json name field

### DIFF
--- a/data/redlab.json
+++ b/data/redlab.json
@@ -1,5 +1,5 @@
 {
-    "name": "Redlab - The Consultancy Solution\n",
+    "name": "Redlab - The Consultancy Solution",
     "url": "https://www.linkedin.com/company/redlabsolution/",
     "career_page_url": "https:/www.linkedin.com/company/redlabsolution/jobs",
     "type": "B2B",


### PR DESCRIPTION
In the `redlab.json` file there is an unnecessary `\n` that causes an error in the generated readme file:
![immagine](https://github.com/italiaremote/awesome-italia-remote/assets/3061752/0adddcb8-3b61-4dbd-8dfa-82d02b5a8416)
