### PR TITLE
Add Klarna

### DIFF
--- a/data/klarna.json
+++ b/data/klarna.json
@@ -1,0 +1,23 @@
+{
+  "name": "Klarna",
+  "career_page_url": "https://jobs.lever.co/klarna/",
+  "url": "https://www.klarna.com/",
+  "remote_policy": "Optional",
+  "hiring_policies": [
+      "Direct"
+  ],
+  "type": "Product",
+  "categories": [
+    "cloud_software"
+  ],
+  "tags": [
+    "Java",
+    "Python",
+    "Node",
+    "JavaScript",
+    "Typescript",
+    "React",
+    "Docker",
+    "AWS"
+  ]
+}


### PR DESCRIPTION
Adding Klarna, a swedish fintech company with an office in Milan but allowing to work from anywhere in Italy.