### PR TITLE
Create zucchetti.json

### DIFF
--- a/data/zucchetti.json
+++ b/data/zucchetti.json
@@ -1,0 +1,28 @@
+{
+  "name": "Zucchetti S.p.A.",
+  "url": "https://www.zucchetti.it",
+  "career_page_url": "https://www.zucchetti.it/website/cms/zcareers.html",
+  "type": "Product",
+  "categories": [
+    "cloud_software",
+    "cybersecurity"
+  ],
+  "remote_policy": "Hybrid",
+  "hiring_policies": [
+    "Direct"
+  ],
+  "tags": [
+    "Ansible",
+    "Kubernetes",
+    "Java",
+    "PostgreSQL",
+    "Cloud Native",
+    "DevOps",
+    "Go",
+    "OpenShift",
+    "React",
+    "Linux",
+    "CI/CD",
+    "SQL"
+  ]
+}


### PR DESCRIPTION
Adding Zucchetti Group: la prima software house in Italia presente anche in molti paesi esteri con oltre 8.000 risorse, 1.650 partner in Italia e 350 all’estero.