### PR TITLE
Add `ericsson` company

### DIFF
--- a/data/ericsson.json
+++ b/data/ericsson.json
@@ -1,0 +1,21 @@
+{
+    "name": "Ericsson",
+    "career_page_url": "https://www.ericsson.com/en/careers",
+    "url": "https://www.ericsson.com",
+    "remote_policy": "Hybrid",
+    "hiring_policies": [
+        "Direct"
+    ],
+    "type": "B2B",
+    "categories": [
+        "cloud_software"
+    ],
+    "tags": [
+        "Kubernetes",
+        "OpenStack",
+        "Docker",
+        "Linux",
+        "Python",
+        "Ansible"
+    ]
+}


### PR DESCRIPTION
La pull request aggiunge Ericsson alla lista, la quale attualmente adotta una politica di lavoro ibrida.

Ericsson è una società che opera nel settore delle telecomunicazioni che, con l'avvento del 5G, ha abbracciato il mondo cloud-native con Kubernetes, Docker e OpenStack.