### PR TITLE
Fix some career page links

### DIFF
--- a/data/5w155.json
+++ b/data/5w155.json
@@ -1,7 +1,7 @@
 {
   "name": "5w155",
   "url": "https://5w155.ch/",
-  "career_page_url": "https://5w155.ch/careers.html",
+  "career_page_url": "https://5w155.ch/careers",
   "type": "Consulting",
   "categories": [
     "cloud_software"

--- a/data/codiceplastico.json
+++ b/data/codiceplastico.json
@@ -1,7 +1,7 @@
 {
   "name": "CodicePlastico",
   "url": "https://codiceplastico.com/",
-  "career_page_url": "https://codiceplastico.com/jobs/",
+  "career_page_url": "https://codiceplastico.com/",
   "type": "Consulting",
   "categories": [
      "cloud_software",

--- a/data/faceit.json
+++ b/data/faceit.json
@@ -1,7 +1,7 @@
 {
   "name": "FACEIT",
   "url": "https://www.faceit.com/en",
-  "career_page_url": "https://corporate.faceit.com/available-jobs/",
+  "career_page_url": "https://corporate.faceit.com/working-at-faceit/",
   "type": "Product",
   "categories": [
     "cloud_software"

--- a/data/getir.json
+++ b/data/getir.json
@@ -1,7 +1,7 @@
 {
   "name": "Getir",
   "url": "https://getir.com/it/",
-  "career_page_url": "https://apply.workable.com/getir/",
+  "career_page_url": "https://career.getir.com/",
   "type": "Product",
   "categories": [
     "cloud_software"

--- a/data/innoteam.json
+++ b/data/innoteam.json
@@ -1,7 +1,7 @@
 {
   "name": "Innoteam",
   "url": "https://www.innoteam.it/",
-  "career_page_url": "https://labs.innoteam.it/carriere/",
+  "career_page_url": "https://www.axelerant.it/carriere/",
   "type": "Consulting",
   "categories": [
     "cloud_software"

--- a/data/microsoft.json
+++ b/data/microsoft.json
@@ -1,7 +1,7 @@
 {
   "name": "Microsoft",
   "url": "https://www.microsoft.com/it-it/",
-  "career_page_url": "https://careers.microsoft.com/professionals/us/en/search-results?rk=l-c-engineering",
+  "career_page_url": "https://careers.microsoft.com/",
   "type": "Product",
   "categories": [
     "cloud_software"

--- a/data/pinv.json
+++ b/data/pinv.json
@@ -1,7 +1,7 @@
 {
   "name": "Pinv",
   "url": "https://www.pinv.it",
-  "career_page_url": "https://pinv.it/contatti/",
+  "career_page_url": "https://pinv.it/lavora-con-noi/",
   "type": "Product",
   "categories": [
     "cloud_software"


### PR DESCRIPTION
I tryed all the remote Software and Cloud career-page links (https://github.com/italiaremote/awesome-italia-remote#software-and-cloud), and correct some of them. For Innoteam I think the company changed name to Axelerant or was acquired.