### PR TITLE
Fix Wuerth Phoenix career page URL

### DIFF
--- a/data/wuerth_phoenix.json
+++ b/data/wuerth_phoenix.json
@@ -1,6 +1,6 @@
 {
     "name": "Wuerth Phoenix",
-    "career_page_url": "https://wuerth-phoenix.com/it/carriera/carriera-wuerth-phoenix/posizioni-aperte",
+    "career_page_url": "https://www.wuerth-phoenix.com/posizioni-aperte/",
     "url": "https://wuerth-phoenix.com/",
     "remote_policy": "Full",
     "hiring_policies": [

--- a/data/wuerth_phoenix.json
+++ b/data/wuerth_phoenix.json
@@ -1,6 +1,6 @@
 {
     "name": "Wuerth Phoenix",
-    "career_page_url": "https://www.wuerth-phoenix.com/posizioni-aperte/",
+    "career_page_url": "https://www.wuerth-phoenix.com/posizioni-aperte",
     "url": "https://wuerth-phoenix.com/",
     "remote_policy": "Full",
     "hiring_policies": [


### PR DESCRIPTION
As title states, this PR fix Wuerth Phoenix career page URL.
The current one no longer exists and you are redirected to the home page.