### PR TITLE
Fixed name in fastloop.json

### DIFF
--- a/data/fastloop.json
+++ b/data/fastloop.json
@@ -1,5 +1,5 @@
 {
-    "name": "Fifth Beat",
+    "name": "Fastloop",
     "career_page_url": "https://www.fastloop.it/careers/",
     "url": "https://www.fastloop.it/",
     "remote_policy": "Full",


### PR DESCRIPTION
The json file for Fastloop had a name field with the wrong value in it.