### PR TITLE
Update URL for TUI Musement

### DIFF
--- a/data/tui_musement.json
+++ b/data/tui_musement.json
@@ -1,6 +1,6 @@
 {
   "name": "TUI Musement",
-  "url": "https://www.musement.com/",
+  "url": "https://www.tuimusement.com/",
   "career_page_url": "https://careers.tuigroup.com/jobs/",
   "type": "Product",
   "categories": [

--- a/data/tui_musement.json
+++ b/data/tui_musement.json
@@ -8,7 +8,7 @@
   ],
   "remote_policy": "Optional",
   "hiring_policies": [
-    "Direct"
+    "Direct", "Contract"
   ],
   "tags": [
     "AWS",


### PR DESCRIPTION
Update URL for TUI Musement to https://www.tuimusement.com/ as requested by our SEO manager