### PR TITLE
Add Kraken Tech (Octopus Energy)

### DIFF
--- a/data/kraken.json
+++ b/data/kraken.json
@@ -1,0 +1,26 @@
+{
+  "name": "Kraken Tech",
+  "url": "https://kraken.tech",
+  "career_page_url": "https://kraken.tech/jobs",
+  "type": "Product",
+  "categories": [
+    "cloud_software"
+  ],
+  "remote_policy": "Optional",
+  "hiring_policies": [
+    "Direct"
+  ],
+  "tags": [
+    "AWS",
+    "Consul",
+    "Django",
+    "GraphQL",
+    "Kubernetes",
+    "PostgreSQL",
+    "Python",
+    "React",
+    "Redux",
+    "REST API",
+    "Terraform"
+  ]
+}


### PR DESCRIPTION
[Kraken](https://kraken.tech) is the tech company that runs [Octopus Energy](https://octopusenergy.it/). They were present at [PyCon Italia](https://pycon.it) with a booth, in the last few years.

Many, if not all, of their [engineering roles](https://kraken.tech/jobs) are fuil-remote.