### PR TITLE
Add Platform.sh (Platform as a Service)

### DIFF
--- a/data/platform_sh.json
+++ b/data/platform_sh.json
@@ -1,0 +1,25 @@
+{
+  "name": "Platform.sh",
+  "url": "https://platform.sh",
+  "career_page_url": "https://platform.sh/company/careers/",
+  "type": "Product",
+  "categories": [
+    "cloud_software"
+  ],
+  "remote_policy": "Optional",
+  "hiring_policies": [
+    "Direct"
+  ],
+  "tags": [
+    "Cloud Native Technologies",
+    "Debian",
+    "Docker",
+    "GitLab",
+    "Go",
+    "Linux",
+    "Platform Engineering",
+    "PostgreSQL",
+    "Python",
+    "Software Development"
+  ]
+}


### PR DESCRIPTION
Platform.sh is a (French) company that claims to be multicultural, international, dedicated to open source and to an open, welcoming environment.

They currently appear to [recruit engineering roles](https://platform.sh/company/careers/) in Spain, France, Germany, Canada and the UK (where they have [stable offices](https://platform.sh/contact/)), though they say, "[they] welcome applications from all qualified candidates who are legally authorized to work in these countries". Most of their roles are explicitly full-remote.