### PR TITLE
Update palmabit.json as the company has changed its name

### DIFF
--- a/data/palmabit.json
+++ b/data/palmabit.json
@@ -1,7 +1,7 @@
 {
-  "name": "Palmabit",
-  "url": "https://www.palmabit.com",
-  "career_page_url": "https://www.palmabit.com/it/work-with-us",
+  "name": "Webidoo Engineering",
+  "url": "https://www.webidooengineering.com/it",
+  "career_page_url": "https://www.webidooengineering.com/it/work-with-us",
   "type": "Consulting",
   "categories": [
     "cloud_software"
@@ -20,6 +20,7 @@
     "GraphQL",
     "Docker",
     "Kubernetes",
-    "Netlify"
+    "Netlify",
+    "Angular"
   ]
 }


### PR DESCRIPTION
Update Palmabit entry: renamed to Webidoo Engineering, updated links and tags Palmabit has changed its name to Webidoo Engineering.  

- Updated company name accordingly  
- Updated website URL  
- Updated careers page link  
- Added "angular" to the tech stack tags