### PR TITLE
Follow redirect for Stellantis careers page

### DIFF
--- a/data/stellantis.json
+++ b/data/stellantis.json
@@ -1,7 +1,7 @@
 {
   "name": "Stellantis",
   "url": "https://www.stellantis.com/",
-  "career_page_url": "https://careers.fcagroup.com/",
+  "career_page_url": "https://careers.stellantis.com/",
   "type": "Product",
   "categories": [
     "cloud_software"


### PR DESCRIPTION
`careers.fcagroup.com` redirects to `careers.stellantis.com`, update the URL accordingly to avoid redirects.
